### PR TITLE
Add shebang and improve argument validation

### DIFF
--- a/extract_yoast_sitemap.sh
+++ b/extract_yoast_sitemap.sh
@@ -1,22 +1,23 @@
-if [[ $# -eq 0 ]] ; then
-                    echo 'run  extract_yoast_sitemap.sh https://www.yourdomain.com/sitemap_index.xml output.txt'
-                    exit 0
+#!/usr/bin/env bash
+if [[ $# -ne 2 ]]; then
+    echo "Usage: extract_yoast_sitemap.sh <sitemap_index_url> <output_file>"
+    exit 1
 fi
 
 
-echo "# URL list" > $2
+echo "# URL list" > "$2"
 
-main_url=$(curl -s $1 | grep "<loc>" | awk -F"<loc>" '{print $2} ' | awk -F"</loc>" '{print $1}')
+main_url=$(curl -s "$1" | grep "<loc>" | awk -F"<loc>" '{print $2} ' | awk -F"</loc>" '{print $1}')
 
 for i in $main_url
 do
 
-        urls=$(curl -s $i | grep "<loc>" | awk -F"<loc>" '{print $2} ' | awk -F"</loc>" '{print $1}')
+        urls=$(curl -s "$i" | grep "<loc>" | awk -F"<loc>" '{print $2} ' | awk -F"</loc>" '{print $1}')
         for site_url in $urls
         do
 
                 echo "$site_url"
-                echo "$site_url" >> $2
+                echo "$site_url" >> "$2"
 
          done
 


### PR DESCRIPTION
## Summary
- add bash shebang
- validate the script requires exactly two arguments
- quote `$1` and `$2` when used

## Testing
- `bash -n extract_yoast_sitemap.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fe8cf1bcc832a889bfcd9f3da4488