### PR TITLE
Add basic test for extract_yoast_sitemap.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # parse-yoast-sitemap
 Parse yoast sitemap.xml with bash to URL list
+
+## Running Tests
+
+This repository uses [Bats](https://github.com/bats-core/bats-core) for testing. After installing the `bats` package, run:
+
+```bash
+bats tests/extract_yoast_sitemap.bats
+```
+
+The test uses sample sitemaps in `tests/data` and verifies that `extract_yoast_sitemap.sh` outputs the expected URLs.

--- a/tests/data/pages.xml
+++ b/tests/data/pages.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://example.com/page1</loc></url>
+  <url><loc>http://example.com/page2</loc></url>
+</urlset>

--- a/tests/data/posts.xml
+++ b/tests/data/posts.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://example.com/post1</loc></url>
+  <url><loc>http://example.com/post2</loc></url>
+</urlset>

--- a/tests/data/sitemap_index.template.xml
+++ b/tests/data/sitemap_index.template.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>{{ROOT}}/tests/data/posts.xml</loc></sitemap>
+  <sitemap><loc>{{ROOT}}/tests/data/pages.xml</loc></sitemap>
+</sitemapindex>

--- a/tests/extract_yoast_sitemap.bats
+++ b/tests/extract_yoast_sitemap.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMP_OUT="$(mktemp)"
+  TMP_INDEX="$(mktemp)"
+  sed "s|{{ROOT}}|file://${PWD}|g" tests/data/sitemap_index.template.xml > "$TMP_INDEX"
+}
+
+teardown() {
+  rm -f "$TMP_OUT" "$TMP_INDEX"
+}
+
+@test "extracts all URLs from sitemap" {
+  run bash extract_yoast_sitemap.sh "file://$TMP_INDEX" "$TMP_OUT"
+  [ "$status" -eq 0 ]
+  grep -q "http://example.com/page1" "$TMP_OUT"
+  grep -q "http://example.com/page2" "$TMP_OUT"
+  grep -q "http://example.com/post1" "$TMP_OUT"
+  grep -q "http://example.com/post2" "$TMP_OUT"
+}


### PR DESCRIPTION
## Summary
- provide sample sitemap index and sub-sitemaps
- test `extract_yoast_sitemap.sh` with Bats
- document how to run the tests

## Testing
- `bats tests/extract_yoast_sitemap.bats`


------
https://chatgpt.com/codex/tasks/task_e_683fe8de2678832a9559aa7f943377e2