### PR TITLE
Enhance Yoast sitemap parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # parse-yoast-sitemap
 Parse yoast sitemap.xml with bash to URL list
 
+## Requirements
+
+The script depends on `curl` and [`xmlstarlet`](https://xmlstar.sourceforge.net/)
+for parsing XML. To enable parallel sitemap fetching, install the
+`parallel` package and set the `PARALLEL_JOBS` environment variable.
+
 ## Running Tests
 
 This repository uses [Bats](https://github.com/bats-core/bats-core) for testing. After installing the `bats` package, run:


### PR DESCRIPTION
## Summary
- refactor `extract_yoast_sitemap.sh` for better reliability
- add requirement notes for `xmlstarlet` and optional parallel fetch support

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_683fed37fa98832a8381b30fe3fac7d2