### PR TITLE
Ensure fetch_locs exported for xargs

### DIFF
--- a/extract_yoast_sitemap.sh
+++ b/extract_yoast_sitemap.sh
@@ -31,6 +31,7 @@ main() {
 
     local parallel_jobs="${PARALLEL_JOBS:-1}"
     if [[ "$parallel_jobs" -gt 1 ]]; then
+        export -f fetch_locs
         printf '%s\n' "${sitemaps[@]}" | \
             xargs -n1 -P "$parallel_jobs" -I{} bash -c 'fetch_locs "$1"' _ {} >> "$output_file"
     else

--- a/tests/extract_yoast_sitemap.bats
+++ b/tests/extract_yoast_sitemap.bats
@@ -18,3 +18,12 @@ teardown() {
   grep -q "http://example.com/post1" "$TMP_OUT"
   grep -q "http://example.com/post2" "$TMP_OUT"
 }
+
+@test "extracts URLs in parallel" {
+  PARALLEL_JOBS=2 run bash extract_yoast_sitemap.sh "file://$TMP_INDEX" "$TMP_OUT"
+  [ "$status" -eq 0 ]
+  grep -q "http://example.com/page1" "$TMP_OUT"
+  grep -q "http://example.com/page2" "$TMP_OUT"
+  grep -q "http://example.com/post1" "$TMP_OUT"
+  grep -q "http://example.com/post2" "$TMP_OUT"
+}


### PR DESCRIPTION
## Summary
- export `fetch_locs` when running in parallel
- test parallel path

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_683ff9d3aafc832aa017e86fda18af98