### PR TITLE
Add robots.txt sitemap discovery

### DIFF
--- a/tests/data/robots.template.txt
+++ b/tests/data/robots.template.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: {{SITEMAP}}

--- a/tests/extract_yoast_sitemap.bats
+++ b/tests/extract_yoast_sitemap.bats
@@ -2,12 +2,15 @@
 
 setup() {
   TMP_OUT="$(mktemp)"
-  TMP_INDEX="$(mktemp)"
+  TMP_INDEX="$(mktemp --suffix=.xml)"
   sed "s|{{ROOT}}|file://${PWD}|g" tests/data/sitemap_index.template.xml > "$TMP_INDEX"
+  TMP_ROBOT_DIR="$(mktemp -d)"
+  sed "s|{{SITEMAP}}|file://$TMP_INDEX|g" tests/data/robots.template.txt > "$TMP_ROBOT_DIR/robots.txt"
 }
 
 teardown() {
   rm -f "$TMP_OUT" "$TMP_INDEX"
+  rm -rf "$TMP_ROBOT_DIR"
 }
 
 @test "extracts all URLs from sitemap" {
@@ -21,6 +24,15 @@ teardown() {
 
 @test "extracts URLs in parallel" {
   PARALLEL_JOBS=2 run bash extract_yoast_sitemap.sh "file://$TMP_INDEX" "$TMP_OUT"
+  [ "$status" -eq 0 ]
+  grep -q "http://example.com/page1" "$TMP_OUT"
+  grep -q "http://example.com/page2" "$TMP_OUT"
+  grep -q "http://example.com/post1" "$TMP_OUT"
+  grep -q "http://example.com/post2" "$TMP_OUT"
+}
+
+@test "auto-detects index from robots.txt" {
+  run bash extract_yoast_sitemap.sh "file://$TMP_ROBOT_DIR" "$TMP_OUT"
   [ "$status" -eq 0 ]
   grep -q "http://example.com/page1" "$TMP_OUT"
   grep -q "http://example.com/page2" "$TMP_OUT"


### PR DESCRIPTION
## Summary
- detect sitemap index from robots.txt when argument isn't an XML URL
- support robots file in tests
- test auto-detection of sitemap index

## Testing
- `npx bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_683ffe45f040832a8984ee2ea3c1638e