### PR TITLE
Expand docs and add CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
 # parse-yoast-sitemap
-Parse yoast sitemap.xml with bash to URL list
+Parse Yoast sitemap.xml files with Bash and output a flat list of URLs.
+
+## Purpose
+This script was written to quickly extract every URL from a Yoast generated
+sitemap index. It reads the index, follows each sitemap entry and prints all
+`<loc>` values to a file. The goal is to provide a small and dependency-light
+tool for crawling or auditing tasks.
+
+## History
+Created by **Johan Caripson**, the project began as a short helper script and
+gradually evolved with tests and parallel execution support.
 
 ## Requirements
 
-The script depends on `curl` and [`xmlstarlet`](https://xmlstar.sourceforge.net/).
-Both commands must be installed for the script to run. By default, sitemaps
-are processed sequentially. To fetch them in parallel, set the
-`PARALLEL_JOBS` environment variable; parallel execution relies on `xargs`
-to spawn multiple workers.
+The script depends on `curl`, [`xmlstarlet`](https://xmlstar.sourceforge.net/)
+and `gzip` for handling compressed sitemaps. By default, sitemaps are processed
+sequentially. To fetch them in parallel, either set the `PARALLEL_JOBS`
+environment variable or pass `-j` on the command line; parallel execution
+relies on `xargs` to spawn multiple workers.
+
+## Usage
+
+```bash
+bash extract_yoast_sitemap.sh [-j jobs] [-u user-agent] <sitemap_index_url> <output_file>
+```
+
+- `-j` sets the number of parallel workers (default is `1`).
+- `-u` specifies a custom User-Agent string for `curl`.
+
+Sitemaps ending in `.gz` are automatically decompressed if `gzip` is available.
 
 ## Running Tests
 
@@ -19,6 +40,22 @@ bats tests/extract_yoast_sitemap.bats
 
 The test uses sample sitemaps in `tests/data` and verifies that `extract_yoast_sitemap.sh` outputs the expected URLs.
 
+## How to Verify
+
+1. Run the script against a known sitemap index.
+2. Confirm that the resulting file contains every expected URL.
+3. Optionally execute the Bats tests with `bats tests/extract_yoast_sitemap.bats` to ensure all automated checks pass.
+
+## Future Improvements
+
+* Better error handling when downloading sitemaps.
+* Support incremental updates to avoid reprocessing unchanged files.
+* Provide a Docker wrapper for easier distribution.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+## Author
+
+Johan Caripson


### PR DESCRIPTION
## Summary
- document tool purpose, history, future work and how to verify
- document new `-j` and `-u` command line options
- mention gzip support in README
- credit Johan Caripson as the author
- add new options and gzip handling to `extract_yoast_sitemap.sh`

## Testing
- `bats tests/extract_yoast_sitemap.bats` *(fails: `bats` not found)*
- `shellcheck extract_yoast_sitemap.sh` *(fails: `shellcheck` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe45de28832a9135befff3fdc025