### PR TITLE
Add command checks

### DIFF
--- a/extract_yoast_sitemap.sh
+++ b/extract_yoast_sitemap.sh
@@ -5,6 +5,13 @@
 # variables as an error and make pipelines fail if any command fails.
 set -euo pipefail
 
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Required command '$1' not found" >&2
+        exit 1
+    fi
+}
+
 usage() {
     # Print script usage information and exit with an error code.
     echo "Usage: $0 [-j jobs] <sitemap_index_url> <output_file>" >&2
@@ -20,6 +27,8 @@ fetch_locs() {
 }
 
 main() {
+    require_command curl
+    require_command xmlstarlet
     # Parse options; currently only -j for specifying parallel jobs.
     local cli_jobs=""
     while getopts "j:" opt; do

--- a/tests/extract_yoast_sitemap.bats
+++ b/tests/extract_yoast_sitemap.bats
@@ -36,3 +36,21 @@ teardown() {
   grep -q "http://example.com/post1" "$TMP_OUT"
   grep -q "http://example.com/post2" "$TMP_OUT"
 }
+
+@test "errors when curl is missing" {
+  BIN_DIR="$(mktemp -d)"
+  ln -s "$(command -v xmlstarlet)" "$BIN_DIR/xmlstarlet"
+  ln -s "$(command -v touch)" "$BIN_DIR/touch"
+  PATH="$BIN_DIR" run /usr/bin/bash extract_yoast_sitemap.sh "file://$TMP_INDEX" "$TMP_OUT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *curl* ]]
+}
+
+@test "errors when xmlstarlet is missing" {
+  BIN_DIR="$(mktemp -d)"
+  ln -s "$(command -v curl)" "$BIN_DIR/curl"
+  ln -s "$(command -v touch)" "$BIN_DIR/touch"
+  PATH="$BIN_DIR" run /usr/bin/bash extract_yoast_sitemap.sh "file://$TMP_INDEX" "$TMP_OUT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *xmlstarlet* ]]
+}


### PR DESCRIPTION
## Summary
- verify necessary commands exist before executing the script
- fail early if `curl` or `xmlstarlet` is missing
- cover the new checks with Bats tests

## Testing
- `bats -r tests`

------
https://chatgpt.com/codex/tasks/task_e_684001b94504832aa7e51631fb4ca5b8