### PR TITLE
Add installation info and example run

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ are processed sequentially. To fetch them in parallel, set the
 `PARALLEL_JOBS` environment variable or pass `-j <jobs>` on the command
 line; parallel execution relies on `xargs` to spawn multiple workers.
 
+## 🚀 Installation
+
+Use your system package manager to install the required tools:
+
+* **Linux (apt)**
+
+  ```bash
+  sudo apt-get update && sudo apt-get install curl xmlstarlet
+  ```
+
+* **macOS (brew)**
+
+  ```bash
+  brew install curl xmlstarlet
+  ```
+
+Both commands must be available in your `PATH` before running the script.
+
+
 ## Running Tests
 
 This repository uses [Bats](https://github.com/bats-core/bats-core) for testing. After installing the `bats` package, run:
@@ -17,7 +36,20 @@ This repository uses [Bats](https://github.com/bats-core/bats-core) for testing.
 bats tests/extract_yoast_sitemap.bats
 ```
 
+
 The test uses sample sitemaps in `tests/data` and verifies that `extract_yoast_sitemap.sh` outputs the expected URLs.
+
+## 📝 Example Run
+
+```bash
+./extract_yoast_sitemap.sh https://example.com/sitemap_index.xml urls.txt
+cat urls.txt
+```
+
+
+## 🛠️ Troubleshooting
+
+If `curl` or `xmlstarlet` are missing in the Codex environment, tests may fail. Enable internet access or provide a setup script to install the packages before running tests.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document installing requirements with apt or brew
- show how to run `extract_yoast_sitemap.sh`
- mention troubleshooting tips for Codex

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_684002f257a4832abd03ce37825dc520