### PR TITLE
Add multi-domain JSON config

### DIFF
--- a/tests/data/index1.template.xml
+++ b/tests/data/index1.template.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>{{ROOT}}/tests/data/posts.xml</loc></sitemap>
+</sitemapindex>

--- a/tests/data/index2.template.xml
+++ b/tests/data/index2.template.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>{{ROOT}}/tests/data/pages.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
## Summary
- add jq dependency and parse a JSON config listing domain sitemap indexes
- process every domain's index sequentially or in parallel
- expand tests to use JSON config and cover jq missing case
- add sample index templates for tests

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_684006f8b2d4832aa1b044407e904e87