### PR TITLE
Add Docker support and URL filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl xmlstarlet jq bash \
+    && rm -rf /var/lib/apt/lists/*
+COPY extract_yoast_sitemap.sh /usr/local/bin/
+WORKDIR /data
+ENTRYPOINT ["bash", "/usr/local/bin/extract_yoast_sitemap.sh"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ default, sitemaps are processed sequentially. To fetch them in parallel, set the
 ## 📥 Usage
 
 ```bash
-./extract_yoast_sitemap.sh [-e] [-j jobs] [-a user_agent] <config_file> <output_file>
+./extract_yoast_sitemap.sh [-e] [-j jobs] [-a user_agent] [-f pattern] <config_file> <output_file>
 ```
 
 ### Flags
@@ -36,6 +36,7 @@ default, sitemaps are processed sequentially. To fetch them in parallel, set the
 * `-e` &nbsp; echo each extracted URL to stdout
 * `-j` &nbsp; run multiple workers in parallel
 * `-a` &nbsp; specify a custom User-Agent header when fetching sitemaps
+* `-f` &nbsp; only include URLs matching the given pattern
 
 ## 🚀 Installation
 
@@ -70,8 +71,17 @@ The test uses sample sitemaps in `tests/data` and verifies that `extract_yoast_s
 ## 📝 Example Run
 
 ```bash
-./extract_yoast_sitemap.sh -e -a "MyBot/1.0" https://example.com/sitemap_index.xml urls.txt
+./extract_yoast_sitemap.sh -e -a "MyBot/1.0" -f page https://example.com/sitemap_index.xml urls.txt
 cat urls.txt
+```
+
+## 🐳 Running with Docker
+
+Build the image and run the script inside a container:
+
+```bash
+docker build -t yoast-sitemap .
+docker run --rm -v "$PWD":/data yoast-sitemap /data/config.json /data/urls.txt
 ```
 
 ## 🔭 Future Work
@@ -79,8 +89,6 @@ cat urls.txt
 Here are a few ideas for how this project could evolve:
 
 * Support for compressed (`.gz`) sitemaps
-* Docker container for reproducible runs
-* Option to filter URLs by pattern
 
 
 ## 🛠️ Troubleshooting

--- a/tests/extract_yoast_sitemap.bats
+++ b/tests/extract_yoast_sitemap.bats
@@ -31,6 +31,16 @@ teardown() {
   [[ "$output" == *"✅ Extracted 4 URLs."* ]]
 }
 
+@test "filters URLs with -f" {
+  run bash extract_yoast_sitemap.sh -f page "$TMP_CONFIG" "$TMP_OUT"
+  [ "$status" -eq 0 ]
+  grep -q "http://example.com/page1" "$TMP_OUT"
+  grep -q "http://example.com/page2" "$TMP_OUT"
+  ! grep -q "http://example.com/post1" "$TMP_OUT"
+  ! grep -q "http://example.com/post2" "$TMP_OUT"
+  [[ "$output" == *"✅ Extracted 2 URLs."* ]]
+}
+
 @test "extracts URLs in parallel" {
   PARALLEL_JOBS=2 run bash extract_yoast_sitemap.sh "$TMP_CONFIG" "$TMP_OUT"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- add new `-f` option to filter URLs by regex pattern
- create Dockerfile for reproducible runs
- document new option and Docker usage in README
- test URL filtering

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_68401912cde8832a8ba599f2318ad33b