### PR TITLE
Add optional C parser for faster sitemap processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ default, sitemaps are processed sequentially. To fetch them in parallel, set the
 * `-j` &nbsp; run multiple workers in parallel
 * `-a` &nbsp; specify a custom User-Agent header when fetching sitemaps
 * `-f` &nbsp; only include URLs matching the given pattern
+* `-c` &nbsp; use the optional C parser for URL extraction
 
 ## 🚀 Installation
 
@@ -53,6 +54,13 @@ Use your system package manager to install the required tools:
   ```bash
   brew install curl xmlstarlet jq
   ```
+
+To enable the optional C parser, also install the `libxml2` development
+package and compile the helper binary:
+
+```bash
+gcc extract_locs.c -o extract_locs $(xml2-config --cflags --libs)
+```
 
 All of the above commands must be available in your `PATH` before running the script.
 
@@ -71,7 +79,7 @@ The test uses sample sitemaps in `tests/data` and verifies that `extract_yoast_s
 ## 📝 Example Run
 
 ```bash
-./extract_yoast_sitemap.sh -e -a "MyBot/1.0" -f page https://example.com/sitemap_index.xml urls.txt
+./extract_yoast_sitemap.sh -e -c -a "MyBot/1.0" -f page https://example.com/sitemap_index.xml urls.txt
 cat urls.txt
 ```
 

--- a/extract_locs.c
+++ b/extract_locs.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <libxml/parser.h>
+#include <libxml/xpath.h>
+
+int main(void) {
+    xmlDocPtr doc = xmlReadFd(0, NULL, NULL, 0);
+    if (!doc) {
+        fprintf(stderr, "Failed to parse XML\n");
+        return 1;
+    }
+
+    xmlXPathContextPtr ctx = xmlXPathNewContext(doc);
+    if (!ctx) {
+        fprintf(stderr, "Failed to create XPath context\n");
+        xmlFreeDoc(doc);
+        return 1;
+    }
+
+    xmlXPathObjectPtr obj = xmlXPathEvalExpression((xmlChar*)"//*[local-name()='loc']", ctx);
+    if (obj && obj->type == XPATH_NODESET && obj->nodesetval) {
+        xmlNodeSetPtr nodes = obj->nodesetval;
+        for (int i = 0; i < nodes->nodeNr; i++) {
+            xmlChar *content = xmlNodeGetContent(nodes->nodeTab[i]);
+            if (content) {
+                printf("%s\n", content);
+                xmlFree(content);
+            }
+        }
+    }
+
+    if (obj)
+        xmlXPathFreeObject(obj);
+    xmlXPathFreeContext(ctx);
+    xmlFreeDoc(doc);
+    xmlCleanupParser();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `extract_locs.c` for fast XML parsing via libxml2
- add `-c` flag in `extract_yoast_sitemap.sh` to use the C parser
- document new flag and build instructions
- update tests to compile and exercise the C parser

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_68401b62315c832a941b182d8ceadd4c