### PR TITLE
Add realtime reporting webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,37 @@ bash extract_yoast_sitemap.sh -a "MyBot/1.0" config.json urls.txt
 bash extract_yoast_sitemap.sh -c -j 2 config.json urls.txt
 ```
 
+## 📊 Real-Time Reporting
+
+Run the optional web server to monitor changes live. First install the Python
+packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+Create a `server_config.json` based on `server_config.example.json` and start the
+server:
+
+```bash
+cp server_config.example.json server_config.json
+python3 serve_reports.py
+```
+
+Open `http://localhost:8000` in your browser to see the latest statistics. The
+page automatically refreshes based on the `refresh_interval` setting.
+
+## 🛡 Best Practices
+
+* Keep the `cache` directory under version control if you want reproducible
+  reports.
+* Store report JSON files in a dedicated folder such as `reports/`.
+* Schedule regular sitemap checks via cron and point the web server to the same
+  report file for historical trends.
+
+## 📜 Change Log
+
+* Added trending charts and a built-in Flask server for real-time monitoring.
+* `extract_yoast_sitemap.sh` now records timestamps in JSON reports.
+* Included `requirements.txt` and `server_config.example.json`.
+

--- a/extract_yoast_sitemap.sh
+++ b/extract_yoast_sitemap.sh
@@ -98,17 +98,19 @@ generate_report() {
     fi
 
     if [[ -n "${REPORT_JSON_FILE:-}" ]]; then
-        local added_json removed_json changed_json
+        local added_json removed_json changed_json ts
         added_json=$(printf '%s\n' "${added[@]}" | jq -Rn '[inputs] | map(select(length>0))')
         removed_json=$(printf '%s\n' "${removed[@]}" | jq -Rn '[inputs] | map(select(length>0))')
         changed_json=$(printf '%s\n' "${changed[@]}" | jq -Rn '[inputs] | map(select(length>0))')
+        ts=$(date -r "$new_file" +"%s")
         jq -n --arg url "$url" \
               --argjson old_size "$old_size" \
               --argjson new_size "$new_size" \
+              --arg timestamp "$ts" \
               --argjson added_urls "$added_json" \
               --argjson removed_urls "$removed_json" \
               --argjson changed_urls "$changed_json" \
-              '{url:$url, old_size:$old_size, new_size:$new_size, added_urls:$added_urls, removed_urls:$removed_urls, changed_urls:$changed_urls}' >> "$REPORT_JSON_FILE"
+              '{url:$url, old_size:$old_size, new_size:$new_size, timestamp:($timestamp|tonumber), added_urls:$added_urls, removed_urls:$removed_urls, changed_urls:$changed_urls}' >> "$REPORT_JSON_FILE"
     fi
     rm -f "$tmp_old" "$tmp_new"
 }

--- a/process_report.py
+++ b/process_report.py
@@ -2,6 +2,8 @@ import json
 import sys
 import base64
 import io
+import datetime
+from collections import defaultdict
 
 try:
     import matplotlib.pyplot as plt
@@ -23,9 +25,29 @@ added = sum(len(d.get('added_urls', [])) for d in data)
 changed = sum(len(d.get('changed_urls', [])) for d in data)
 removed = sum(len(d.get('removed_urls', [])) for d in data)
 
-plt.figure()
+daily = defaultdict(lambda: {'added': 0, 'changed': 0, 'removed': 0})
+for entry in data:
+    ts = entry.get('timestamp')
+    if isinstance(ts, (int, float)):
+        day = datetime.datetime.utcfromtimestamp(ts).date()
+    elif isinstance(ts, str):
+        try:
+            day = datetime.date.fromisoformat(ts.split('T')[0])
+        except Exception:
+            continue
+    else:
+        continue
+    daily[str(day)]['added'] += len(entry.get('added_urls', []))
+    daily[str(day)]['changed'] += len(entry.get('changed_urls', []))
+    daily[str(day)]['removed'] += len(entry.get('removed_urls', []))
+
+days = sorted(daily.keys())
+added_series = [daily[d]['added'] for d in days]
+changed_series = [daily[d]['changed'] for d in days]
+removed_series = [daily[d]['removed'] for d in days]
+plt.figure(figsize=(6, 4))
 plt.bar(['Added', 'Changed', 'Removed'], [added, changed, removed])
-plt.title('URL Changes')
+plt.title('Total URL Changes')
 plt.ylabel('Count')
 img_buf = io.BytesIO()
 plt.savefig(img_buf, format='png')
@@ -33,12 +55,30 @@ img_buf.seek(0)
 img_b64 = base64.b64encode(img_buf.read()).decode('utf-8')
 img_buf.close()
 
+plt.figure(figsize=(8, 4))
+plt.plot(days, added_series, label='Added', marker='o')
+plt.plot(days, changed_series, label='Changed', marker='o')
+plt.plot(days, removed_series, label='Removed', marker='o')
+plt.legend()
+plt.title('Daily URL Changes')
+plt.xlabel('Day')
+plt.ylabel('Count')
+plt.xticks(rotation=45, ha='right')
+plt.tight_layout()
+trend_buf = io.BytesIO()
+plt.savefig(trend_buf, format='png')
+trend_buf.seek(0)
+trend_b64 = base64.b64encode(trend_buf.read()).decode('utf-8')
+trend_buf.close()
+
 html = f"""<html><body>
 <h1>Sitemap Report</h1>
 <p>Total added URLs: {added}</p>
 <p>Total changed URLs: {changed}</p>
 <p>Total removed URLs: {removed}</p>
 <img src='data:image/png;base64,{img_b64}'/>
+<h2>Trend</h2>
+<img src='data:image/png;base64,{trend_b64}'/>
 </body></html>"""
 with open(html_out, 'w') as f:
     f.write(html)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+matplotlib
+weasyprint

--- a/serve_reports.py
+++ b/serve_reports.py
@@ -1,0 +1,71 @@
+import json
+import datetime
+from flask import Flask
+
+app = Flask(__name__)
+
+CONFIG_PATH = 'server_config.json'
+
+def load_config():
+    try:
+        with open(CONFIG_PATH, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return {"port": 8000, "report_json": "report.json", "refresh_interval": 5}
+
+def load_report(path):
+    data = []
+    try:
+        with open(path, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    data.append(json.loads(line))
+    except FileNotFoundError:
+        pass
+    return data
+
+@app.route('/')
+def index():
+    cfg = load_config()
+    data = load_report(cfg.get('report_json'))
+    added = sum(len(d.get('added_urls', [])) for d in data)
+    changed = sum(len(d.get('changed_urls', [])) for d in data)
+    removed = sum(len(d.get('removed_urls', [])) for d in data)
+    rows = []
+    for d in data[-10:][::-1]:
+        ts = d.get('timestamp')
+        if isinstance(ts, (int, float)):
+            ts = datetime.datetime.utcfromtimestamp(ts).isoformat()
+        rows.append({
+            'time': ts,
+            'added': len(d.get('added_urls', [])),
+            'changed': len(d.get('changed_urls', [])),
+            'removed': len(d.get('removed_urls', []))
+        })
+    html = """
+    <html><head>
+    <meta http-equiv='refresh' content='{ref}'>
+    <style>table,th,td{{border:1px solid #ccc;border-collapse:collapse;padding:4px;}}</style>
+    </head><body>
+    <h1>Real-Time Sitemap Report</h1>
+    <p>Total added: {added} | Total changed: {changed} | Total removed: {removed}</p>
+    <table>
+    <tr><th>Timestamp</th><th>Added</th><th>Changed</th><th>Removed</th></tr>
+    {rows}
+    </table>
+    </body></html>
+    """.format(
+        ref=cfg.get('refresh_interval', 5),
+        added=added,
+        changed=changed,
+        removed=removed,
+        rows="\n".join(
+            f"<tr><td>{r['time']}</td><td>{r['added']}</td><td>{r['changed']}</td><td>{r['removed']}</td></tr>" for r in rows
+        )
+    )
+    return html
+
+if __name__ == '__main__':
+    cfg = load_config()
+    app.run(host='0.0.0.0', port=cfg.get('port', 8000), debug=True)

--- a/server_config.example.json
+++ b/server_config.example.json
@@ -1,0 +1,5 @@
+{
+  "port": 8000,
+  "report_json": "report.json",
+  "refresh_interval": 5
+}


### PR DESCRIPTION
## Summary
- extend JSON report with timestamps
- add trend chart generation in `process_report.py`
- implement `serve_reports.py` Flask server for live stats
- add example server config and requirements list
- document realtime server and best practices

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_68402d878728832ab3d11fa70b0784ec