### PR TITLE
Add curl fail flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ default, sitemaps are processed sequentially. To fetch them in parallel, set the
 * `--report-csv` &nbsp; append detailed change rows to the given CSV file
 * `--process-report` &nbsp; create an HTML/PDF report from the JSON data
 
+The script uses `curl --fail`, so any HTTP error (status code >= 400) will
+terminate execution with a non-zero exit code.
+
 ## 🚀 Installation
 
 Use your system package manager to install the required tools:

--- a/extract_yoast_sitemap.sh
+++ b/extract_yoast_sitemap.sh
@@ -118,7 +118,7 @@ generate_report() {
 fetch_locs() {
     # Retrieve all <loc> entries from the sitemap passed as the first argument.
     local url="$1"
-    local -a curl_cmd=(curl -s)
+    local -a curl_cmd=(curl -sf)
     if [[ -n "$USER_AGENT" ]]; then
         curl_cmd+=( -A "$USER_AGENT" )
     fi


### PR DESCRIPTION
## Summary
- ensure curl aborts on HTTP errors by using `curl --fail`
- document the new behavior in the README

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_684033008bd8832aac6f266cff44c247