### PR TITLE
Add pytest for process_report and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats curl xmlstarlet jq gcc libxml2 libxml2-dev
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install matplotlib pytest
+      - name: Run Bats tests
+        run: bats tests/extract_yoast_sitemap.bats
+      - name: Run Pytest
+        run: pytest -v

--- a/README.md
+++ b/README.md
@@ -90,14 +90,18 @@ same across Linux and macOS.
 
 ## 🧪 Running Tests
 
-This repository uses [Bats](https://github.com/bats-core/bats-core) for testing. After installing the `bats` package, run:
+This repository uses [Bats](https://github.com/bats-core/bats-core) and
+[pytest](https://docs.pytest.org/) for testing. After installing the `bats`
+package and Python dependencies, run:
 
 ```bash
 bats tests/extract_yoast_sitemap.bats
+pytest
 ```
 
-
-The test uses sample sitemaps in `tests/data` and verifies that `extract_yoast_sitemap.sh` outputs the expected URLs.
+The Bats suite uses sample sitemaps in `tests/data` and verifies that
+`extract_yoast_sitemap.sh` outputs the expected URLs. The pytest suite checks the
+`process_report.py` helper.
 
 ## 📝 Example Run
 

--- a/tests/test_process_report.py
+++ b/tests/test_process_report.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_process_report_generates_summary(tmp_path: Path):
+    # Create sample JSON report
+    report_path = tmp_path / "report.json"
+    entries = [
+        {
+            "timestamp": "2023-10-01T00:00:00Z",
+            "added_urls": ["a", "b"],
+            "changed_urls": ["c"],
+            "removed_urls": []
+        },
+        {
+            "timestamp": "2023-10-02T00:00:00Z",
+            "added_urls": ["d"],
+            "changed_urls": ["e", "f"],
+            "removed_urls": ["g", "h", "i"]
+        },
+    ]
+    with report_path.open("w") as f:
+        for e in entries:
+            json.dump(e, f)
+            f.write("\n")
+
+    html_out = tmp_path / "out.html"
+    subprocess.run([
+        "python3",
+        str(Path(__file__).resolve().parents[1] / "process_report.py"),
+        str(report_path),
+        str(html_out),
+    ], check=True)
+
+    text = html_out.read_text()
+    assert "Total added URLs: 3" in text
+    assert "Total changed URLs: 3" in text
+    assert "Total removed URLs: 3" in text


### PR DESCRIPTION
## Summary
- add pytest for `process_report.py`
- document how to run both test suites
- run bats and pytest in GitHub Actions CI

## Testing
- `bats tests/extract_yoast_sitemap.bats`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684035a58f54832abaa5336ff864193b