### PR TITLE
Add main entry point for serve_reports

### DIFF
--- a/serve_reports.py
+++ b/serve_reports.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+
+import argparse
 import json
 import datetime
 from flask import Flask
@@ -66,6 +69,23 @@ def index():
     )
     return html
 
-if __name__ == '__main__':
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Serve real-time reports')
+    parser.add_argument(
+        'config',
+        nargs='?',
+        default='server_config.json',
+        help='Path to server configuration JSON'
+    )
+    args = parser.parse_args()
+
+    global CONFIG_PATH
+    CONFIG_PATH = args.config
+
     cfg = load_config()
     app.run(host='0.0.0.0', port=cfg.get('port', 8000), debug=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- make `serve_reports.py` executable with a shebang
- expose CLI argument for custom config path and wrap in `main()`
- update script entry point to call `main()`

## Testing
- `bats tests/extract_yoast_sitemap.bats`

------
https://chatgpt.com/codex/tasks/task_e_684031a168f4832aab3fee34e0add257