### PR TITLE
Improve live report look and add interval flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,15 @@ python3 serve_reports.py
 ```
 
 Edit `server_config.json` to change the port or choose a different JSON file to
-monitor. By default the server reads `report.json` on port `8000`.
+monitor. By default the server reads `report.json` on port `8000`. You can also
+override the refresh interval with the `--interval` flag when starting the
+server:
+
+```bash
+python3 serve_reports.py --interval 10
+```
+
+The real-time page now uses Bootstrap and Bootstrap Icons for a cleaner look.
 
 Open `http://localhost:8000` in your browser to see the latest statistics. The
 page automatically refreshes based on the `refresh_interval` setting.

--- a/src/yoast_monitor/serve_reports.py
+++ b/src/yoast_monitor/serve_reports.py
@@ -9,6 +9,7 @@ import psutil
 app = Flask(__name__)
 
 CONFIG_PATH = "server_config.json"
+OVERRIDE_INTERVAL = None
 
 
 def load_config():
@@ -35,6 +36,8 @@ def load_report(path):
 @app.route("/")
 def index():
     cfg = load_config()
+    if OVERRIDE_INTERVAL is not None:
+        cfg["refresh_interval"] = OVERRIDE_INTERVAL
     data = load_report(cfg.get("report_json"))
     stats = {
         "cpu": psutil.cpu_percent(interval=0.1),
@@ -58,16 +61,24 @@ def index():
             }
         )
     html = """
-    <html><head>
+    <!doctype html>
+    <html lang='en'>
+    <head>
+    <meta charset='utf-8'>
     <meta http-equiv='refresh' content='{ref}'>
-    <style>table,th,td{{border:1px solid #ccc;border-collapse:collapse;padding:4px;}}</style>
-    </head><body>
-    <h1>Real-Time Sitemap Report</h1>
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css'>
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css'>
+    <title>Real-Time Sitemap Report</title>
+    </head>
+    <body class='container py-4'>
+    <h1 class='mb-4'><i class='bi bi-graph-up'></i> Real-Time Sitemap Report</h1>
     <p>CPU Usage: {cpu:.1f}% | Memory: {mem_used:.1f}/{mem_total:.1f} MB | Disk Read: {disk_read}B | Disk Write: {disk_write}B</p>
-    <p>Total added: {added} | Total changed: {changed} | Total removed: {removed}</p>
-    <table>
-    <tr><th>Timestamp</th><th>Added</th><th>Changed</th><th>Removed</th></tr>
+    <p class='mb-3'>Total added: {added} | Total changed: {changed} | Total removed: {removed}</p>
+    <table class='table table-striped'>
+    <thead><tr><th>Timestamp</th><th><i class='bi bi-plus-circle'></i> Added</th><th><i class='bi bi-arrow-repeat'></i> Changed</th><th><i class='bi bi-dash-circle'></i> Removed</th></tr></thead>
+    <tbody>
     {rows}
+    </tbody>
     </table>
     </body></html>
     """.format(
@@ -96,12 +107,22 @@ def main(argv=None) -> None:
         default="server_config.json",
         help="Path to server configuration JSON",
     )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        help="Override refresh interval in seconds",
+    )
     args = parser.parse_args(argv)
 
     global CONFIG_PATH
     CONFIG_PATH = args.config
 
+    global OVERRIDE_INTERVAL
+    OVERRIDE_INTERVAL = args.interval
+
     cfg = load_config()
+    if args.interval is not None:
+        cfg["refresh_interval"] = args.interval
     app.run(host="127.0.0.1", port=cfg.get("port", 8000), debug=False)
 
 


### PR DESCRIPTION
## Summary
- add Bootstrap and icons to the realtime web UI
- allow overriding refresh interval with `--interval`
- document the new flag and styling

## Testing
- `pytest -q`
- `bats tests/extract_yoast_sitemap.bats`


------
https://chatgpt.com/codex/tasks/task_e_68404bc49b28832aab6fd2884d4b4c00