### PR TITLE
Fix Ruff invocation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run black
         run: poetry run black --check .
       - name: Run ruff
-        run: poetry run ruff .
+        run: poetry run ruff check .
       - name: Run mypy
         run: poetry run mypy src
       - name: Run bandit


### PR DESCRIPTION
## Summary
- update `ci.yml` to use `ruff check` instead of `ruff .`

## Testing
- `poetry run ruff check .`
- `poetry run mypy --install-types --non-interactive src`
- `poetry run bandit -r src -ll`
- `shellcheck extract_yoast_sitemap.sh`
- `bats tests/extract_yoast_sitemap.bats` *(fails: Required command 'xmlstarlet' not found)*
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68404e4dd2d8832a9f94c0b414be7936