### PR TITLE
Add AWS CLI deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,26 @@ server. Terminate the instance when done:
 python3 ec2_manager.py stop <instance-id>
 ```
 
+### Using the AWS CLI
+
+If you prefer to rely on the AWS CLI rather than boto3, the repository also
+includes `ec2_cli.py`. Ensure the [AWS CLI](https://aws.amazon.com/cli/) is
+installed and configured. Create `ec2_cli_config.json` based on
+`ec2_cli_config.example.json` and run:
+
+```bash
+python3 ec2_cli.py start --config ec2_cli_config.json
+```
+
+The default configuration launches a small Ubuntu instance using the `t3a`
+family. The script ensures that the HTTP port specified in `server_port` is
+open in the security group for the IP range defined by `allowed_ip` (or to the
+world if you use `0.0.0.0/0`). Terminate the instance with:
+
+```bash
+python3 ec2_cli.py stop <instance-id>
+```
+
 
 ## 🛡 Best Practices
 
@@ -283,4 +303,5 @@ python3 ec2_manager.py stop <instance-id>
 * `extract_yoast_sitemap.sh` now records timestamps in JSON reports.
 * Included `requirements.txt` and `server_config.example.json`.
 * Added `ec2_manager.py` for easy EC2 deployment and live server metrics.
+* Added `ec2_cli.py` for deployments via the AWS CLI.
 

--- a/ec2_cli.py
+++ b/ec2_cli.py
@@ -1,0 +1,170 @@
+import argparse
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+DEFAULT_CONFIG = {
+    "ami": "ami-1234567890abcdef0",
+    "instance_type": "t3a.micro",
+    "key_name": "my-key",
+    "security_group": "sg-0123456789abcdef0",
+    "ssh_user": "ubuntu",
+    "ssh_key_path": "~/.ssh/id_rsa",
+    "repo_url": "https://github.com/Caripson/parse-yoast-sitemap.git",
+    "server_port": 8080,
+    "allowed_ip": "0.0.0.0/0",
+}
+
+
+def load_config(path: str) -> dict:
+    if not os.path.exists(path):
+        return DEFAULT_CONFIG
+    with open(path, "r") as f:
+        data = json.load(f)
+    cfg = DEFAULT_CONFIG.copy()
+    cfg.update(data)
+    return cfg
+
+
+def run(cmd: list[str]) -> str:
+    out = subprocess.check_output(cmd, text=True)
+    return out.strip()
+
+
+def wait_for_port(host: str, port: int, timeout: int = 300) -> None:
+    import socket
+
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), timeout=5):
+                return
+        except OSError:
+            time.sleep(5)
+    raise RuntimeError(f"Timed out waiting for {host}:{port}")
+
+
+def start(cfg_path: str) -> None:
+    cfg = load_config(cfg_path)
+    sg = cfg["security_group"]
+    allowed_ip = cfg.get("allowed_ip", "0.0.0.0/0")
+    # Open the configured HTTP port for the given IP range
+    subprocess.run(
+        [
+            "aws",
+            "ec2",
+            "authorize-security-group-ingress",
+            "--group-id",
+            sg,
+            "--protocol",
+            "tcp",
+            "--port",
+            str(cfg.get("server_port", 8080)),
+            "--cidr",
+            allowed_ip,
+        ],
+        check=False,
+    )
+
+    instance_id = run(
+        [
+            "aws",
+            "ec2",
+            "run-instances",
+            "--image-id",
+            cfg["ami"],
+            "--instance-type",
+            cfg["instance_type"],
+            "--key-name",
+            cfg["key_name"],
+            "--security-group-ids",
+            sg,
+            "--query",
+            "Instances[0].InstanceId",
+            "--output",
+            "text",
+        ]
+    )
+    print(f"Starting instance {instance_id} ...")
+    subprocess.check_call(["aws", "ec2", "wait", "instance-running", "--instance-ids", instance_id])
+    ip = run(
+        [
+            "aws",
+            "ec2",
+            "describe-instances",
+            "--instance-ids",
+            instance_id,
+            "--query",
+            "Reservations[0].Instances[0].PublicIpAddress",
+            "--output",
+            "text",
+        ]
+    )
+    print(f"Instance running at {ip}")
+
+    import paramiko
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(
+        ip,
+        username=cfg.get("ssh_user", "ubuntu"),
+        key_filename=os.path.expanduser(cfg.get("ssh_key_path")),
+    )
+
+    repo = cfg.get("repo_url")
+    cmds = [
+        "sudo apt-get update",
+        "sudo apt-get install -y git python3-pip",
+        f"git clone {repo} project",
+        "cd project && pip3 install -r requirements.txt psutil",
+    ]
+    for cmd in cmds:
+        print(f"Running: {cmd}")
+        ssh.exec_command(cmd)
+        time.sleep(2)
+
+    # copy local config files
+    sftp = ssh.open_sftp()
+    for name in ["config.json", "server_config.json"]:
+        local = Path(name)
+        if local.exists():
+            print(f"Uploading {name}")
+            sftp.put(str(local), f"project/{name}")
+    sftp.close()
+
+    start_cmd = (
+        "cd project && nohup python3 -m yoast_monitor.serve_reports "
+        "server_config.json > server.log 2>&1 &"
+    )
+    ssh.exec_command(start_cmd)
+    ssh.close()
+
+    wait_for_port(ip, cfg.get("server_port", 8080))
+    print(f"Server running at http://{ip}:{cfg.get('server_port',8080)}")
+    print(f"Instance ID: {instance_id}")
+
+
+def stop(instance_id: str) -> None:
+    print(f"Terminating {instance_id} ...")
+    subprocess.check_call(["aws", "ec2", "terminate-instances", "--instance-ids", instance_id])
+    subprocess.check_call(["aws", "ec2", "wait", "instance-terminated", "--instance-ids", instance_id])
+    print("Instance terminated")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Manage EC2 deployment via AWS CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    st = sub.add_parser("start")
+    st.add_argument("--config", default="ec2_cli_config.json")
+
+    sp = sub.add_parser("stop")
+    sp.add_argument("instance_id")
+
+    args = ap.parse_args()
+    if args.cmd == "start":
+        start(args.config)
+    elif args.cmd == "stop":
+        stop(args.instance_id)

--- a/ec2_cli_config.example.json
+++ b/ec2_cli_config.example.json
@@ -1,0 +1,12 @@
+{
+  "ami": "ami-1234567890abcdef0",
+  "instance_type": "t3a.micro",
+  "key_name": "my-key",
+  "security_group": "sg-0123456789abcdef0",
+  "ssh_user": "ubuntu",
+  "ssh_key_path": "~/.ssh/id_rsa",
+  "repo_url": "https://github.com/Caripson/parse-yoast-sitemap.git",
+  "server_port": 8080,
+  "allowed_ip": "203.0.113.10/32"
+}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ Flask = "*"
 matplotlib = "*"
 weasyprint = "*"
 psutil = "*"
+paramiko = "*"
 
 [tool.poetry.scripts]
 yoast-monitor = "yoast_monitor.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ weasyprint
 psutil
 types-Flask
 types-psutil
+paramiko


### PR DESCRIPTION
## Summary
- add `ec2_cli.py` for AWS CLI based deployments
- document AWS CLI option in README
- provide example config for the CLI script
- include paramiko in dependencies
- open the configured HTTP port when starting a CLI instance

## Testing
- `bats tests/extract_yoast_sitemap.bats`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840564cc388832aa979521328b00485